### PR TITLE
fix: align AWS wrapper imports with split postgres roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_db"></a> [db](#module\_db) | git::https://github.com/cloudopsworks/terraform-module-postgres-management.git | v1.0.1 |
+| <a name="module_db"></a> [db](#module\_db) | git::https://github.com/cloudopsworks/terraform-module-postgres-management.git | v1.0.6 |
 | <a name="module_tags"></a> [tags](#module\_tags) | cloudopsworks/tags/local | 1.0.9 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,7 +19,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_db"></a> [db](#module\_db) | git::https://github.com/cloudopsworks/terraform-module-postgres-management.git | v1.0.1 |
+| <a name="module_db"></a> [db](#module\_db) | git::https://github.com/cloudopsworks/terraform-module-postgres-management.git | v1.0.6 |
 | <a name="module_tags"></a> [tags](#module\_tags) | cloudopsworks/tags/local | 1.0.9 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,10 @@
 
 # Import blocks for resources managed by module.db
 # These must be in the root module since import blocks cannot be in child modules.
+# Existing rotation-enabled workspaces must also run a one-time:
+#   tofu state mv module.db.postgresql_role.owner[<key>] module.db.postgresql_role.owner_rotated[<key>]
+#   tofu state mv module.db.postgresql_role.user[<key>]  module.db.postgresql_role.user_rotated[<key>]
+# Terraform cannot encode this split as a safe static moved block while both rotation modes remain supported.
 
 import {
   for_each = {
@@ -20,7 +24,7 @@ import {
 
 import {
   for_each = {
-    for k, db in var.databases : k => db if try(db.import, false) && try(db.create_owner, false)
+    for k, db in var.databases : k => db if try(db.import, false) && try(db.create_owner, false) && var.rotation_lambda_name == ""
   }
   to = module.db.postgresql_role.owner[each.key]
   id = "${each.value.name}_ow"
@@ -28,9 +32,25 @@ import {
 
 import {
   for_each = {
-    for k, user in var.users : k => user if try(user.import, false)
+    for k, db in var.databases : k => db if try(db.import, false) && try(db.create_owner, false) && var.rotation_lambda_name != ""
+  }
+  to = module.db.postgresql_role.owner_rotated[each.key]
+  id = "${each.value.name}_ow"
+}
+
+import {
+  for_each = {
+    for k, user in var.users : k => user if try(user.import, false) && var.rotation_lambda_name == ""
   }
   to = module.db.postgresql_role.user[each.key]
+  id = each.value.name
+}
+
+import {
+  for_each = {
+    for k, user in var.users : k => user if try(user.import, false) && var.rotation_lambda_name != ""
+  }
+  to = module.db.postgresql_role.user_rotated[each.key]
   id = each.value.name
 }
 

--- a/module-db.tf
+++ b/module-db.tf
@@ -25,7 +25,7 @@ locals {
 }
 
 module "db" {
-  source    = "git::https://github.com/cloudopsworks/terraform-module-postgres-management.git?ref=v1.0.1"
+  source    = "git::https://github.com/cloudopsworks/terraform-module-postgres-management.git?ref=v1.0.6"
   providers = { postgresql = postgresql }
 
   is_hub     = var.is_hub


### PR DESCRIPTION
## Summary

- pin the base postgres module to v1.0.6
- split AWS import targets between rotated and non-rotated role addresses
- document the required state move for existing rotation-enabled workspaces

+semver: patch