### PR TITLE
fix: export user Hoop access control

### DIFF
--- a/hoop.tf
+++ b/hoop.tf
@@ -18,14 +18,17 @@ output "hoop_connections" {
     {
       for key, db in var.databases :
       "${local.psql.server_name}-${local.normalized_owner_list[key]}" => {
-        name           = "${local.psql.server_name}-${local.normalized_owner_list[key]}"
-        agent_id       = var.hoop.agent_id
-        type           = "database"
-        subtype        = "postgres"
-        tags           = try(var.hoop.tags, {})
-        access_control = toset(try(var.hoop.access_control, []))
-        access_modes   = { connect = "enabled", exec = "enabled", runbooks = "enabled", schema = "enabled" }
-        import         = try(var.hoop.import, false)
+        name     = "${local.psql.server_name}-${local.normalized_owner_list[key]}"
+        agent_id = var.hoop.agent_id
+        type     = "database"
+        subtype  = "postgres"
+        tags     = try(var.hoop.tags, {})
+        access_control = setunion(
+          toset(try(var.hoop.access_control, [])),
+          toset(try(db.hoop.access_control, []))
+        )
+        access_modes = { connect = "enabled", exec = "enabled", runbooks = "enabled", schema = "enabled" }
+        import       = try(var.hoop.import, false)
         secrets = {
           "envvar:HOST"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${aws_secretsmanager_secret.owner[key].name}${local.hoop_secret_sep}host"
           "envvar:PORT"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${aws_secretsmanager_secret.owner[key].name}${local.hoop_secret_sep}port"
@@ -40,14 +43,17 @@ output "hoop_connections" {
     {
       for key, role_user in var.users :
       "${local.psql.server_name}-${try(role_user.db_ref, "") != "" ? module.db.databases[role_user.db_ref].name : role_user.database_name}-${role_user.name}" => {
-        name           = "${local.psql.server_name}-${try(role_user.db_ref, "") != "" ? module.db.databases[role_user.db_ref].name : role_user.database_name}-${role_user.name}"
-        agent_id       = var.hoop.agent_id
-        type           = "database"
-        subtype        = "postgres"
-        tags           = try(var.hoop.tags, {})
-        access_control = toset(try(var.hoop.access_control, []))
-        access_modes   = { connect = "enabled", exec = "enabled", runbooks = "enabled", schema = "enabled" }
-        import         = try(var.hoop.import, false)
+        name     = "${local.psql.server_name}-${try(role_user.db_ref, "") != "" ? module.db.databases[role_user.db_ref].name : role_user.database_name}-${role_user.name}"
+        agent_id = var.hoop.agent_id
+        type     = "database"
+        subtype  = "postgres"
+        tags     = try(var.hoop.tags, {})
+        access_control = setunion(
+          toset(try(var.hoop.access_control, [])),
+          toset(try(role_user.hoop.access_control, []))
+        )
+        access_modes = { connect = "enabled", exec = "enabled", runbooks = "enabled", schema = "enabled" }
+        import       = try(var.hoop.import, false)
         secrets = {
           "envvar:HOST"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${aws_secretsmanager_secret.user[key].name}${local.hoop_secret_sep}host"
           "envvar:PORT"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${aws_secretsmanager_secret.user[key].name}${local.hoop_secret_sep}port"


### PR DESCRIPTION
## Summary

- Merge per-database `hoop.access_control` into owner Hoop connections
- Merge per-user `hoop.access_control` into exported user Hoop connections
- Keep AWS postgres management consistent with the other released management modules

+semver: fix
